### PR TITLE
DM-11873: Optimize for speed access(assign)ing table columns

### DIFF
--- a/python/lsst/pipe/analysis/colorAnalysis.py
+++ b/python/lsst/pipe/analysis/colorAnalysis.py
@@ -76,8 +76,7 @@ class NumStarLabeller(object):
     def __init__(self, numBands):
         self.numBands = numBands
     def __call__(self, catalog):
-        return np.array([0 if nn == self.numBands else 2 if nn == 0 else 1 for
-                         nn in catalog["numStarFlags"]])
+        return np.array([0 if nn == self.numBands else 2 if nn == 0 else 1 for nn in catalog["numStarFlags"]])
 
 
 class ColorValueInRange(object):

--- a/python/lsst/pipe/analysis/plotUtils.py
+++ b/python/lsst/pipe/analysis/plotUtils.py
@@ -241,8 +241,8 @@ def rotatePixelCoords(sources, width, height, nQuarter):
     xKey = sources.schema.find("slot_Centroid_x").key
     yKey = sources.schema.find("slot_Centroid_y").key
     for s in sources:
-        x0 = s.get(xKey)
-        y0 = s.get(yKey)
+        x0 = s[xKey]
+        y0 = s[yKey]
         if nQuarter == 1:
             s.set(xKey, height - y0 - 1.0)
             s.set(yKey, x0)

--- a/python/lsst/pipe/analysis/visitAnalysis.py
+++ b/python/lsst/pipe/analysis/visitAnalysis.py
@@ -295,12 +295,14 @@ class VisitAnalysisTask(CoaddAnalysisTask):
                 aliasMap = catalog.schema.getAliasMap()
                 for lsstName, otherName in self.config.srcSchemaMap.iteritems():
                     aliasMap.set(lsstName, otherName)
-            catalog = catalog[catalog["deblend_nChild"] == 0].copy(True) # Exclude non-deblended objects
-            self.catLabel = "nChild = 0"
             # purge the catalogs of flagged sources
+            bad = np.zeros(len(catalog), dtype=bool)
+            bad |= catalog["deblend_nChild"] > 0
+            self.catLabel = "nChild = 0"
             for flag in self.config.analysis.flags:
                 if flag in catalog.schema:
-                    catalog = catalog[~catalog[flag]].copy(True)
+                    bad |= catalog[flag]
+            catalog = catalog[~bad].copy(deep=True)
 
             butler = dataRef.getButler()
             metadata = butler.get("calexp_md", dataRef.dataId)


### PR DESCRIPTION
Speed tests reveal that, as of DM-11871, accessing afw table columns
via field names or keys (e.g. cat[filedKey] cat.get(fieldKey),
cat.get(fieldName), and cat[fieldName]) provide the same speed
performance for full column access.  The cat[fieldName] seems
most pythonic and legible, so homogonize the code here to use that
for all full column access instances.  Key prefetching should be
done when looping over rows.