### PR TITLE
Write parquet files to persist compiled catalogs

### DIFF
--- a/python/lsst/pipe/analysis/analysis.py
+++ b/python/lsst/pipe/analysis/analysis.py
@@ -180,10 +180,11 @@ class Analysis(object):
 
         axScatter.tick_params(which="both", direction="in", labelsize=9)
 
-        if camera is not None and len(ccdList) > 0:
-            axTopRight = plt.axes(topRight)
-            axTopRight.set_aspect("equal")
-            plotCameraOutline(plt, axTopRight, camera, ccdList)
+        if camera is not None and ccdList is not None:
+            if len(ccdList) > 0:
+                axTopRight = plt.axes(topRight)
+                axTopRight.set_aspect("equal")
+                plotCameraOutline(plt, axTopRight, camera, ccdList)
 
         # VERY slow for our 'rings' skymap
         #if tractInfo is not None and len(patchList) > 0:

--- a/python/lsst/pipe/analysis/coaddAnalysis.py
+++ b/python/lsst/pipe/analysis/coaddAnalysis.py
@@ -191,6 +191,13 @@ class CoaddAnalysisTask(CmdLineTask):
 
         flagsCat = unforced
 
+        # Create and write parquet tables
+        tableFilenamer = Filenamer(patchRefList[indexExists].getButler(), 'qaTableCoadd',
+                                   patchRefList[indexExists].dataId)
+
+        writeParquet(forced, tableFilenamer(dataId, description='forced'))
+        writeParquet(unforced, tableFilenamer(dataId, description='unforced'))
+
         if self.config.doPlotFootprintNpix:
             self.plotFootprintHist(forced, filenamer(dataId, description="footNpix", style="hist"),
                                    dataId, butler=butler, camera=camera, tractInfo=tractInfo,

--- a/python/lsst/pipe/analysis/colorAnalysis.py
+++ b/python/lsst/pipe/analysis/colorAnalysis.py
@@ -205,6 +205,10 @@ class ColorAnalysisTask(CmdLineTask):
         forced = self.transformCatalogs(forcedCatalogsByFilter, self.config.transforms,
                                         flagsCats=unforcedCatalogsByFilter, hscRun=hscRun)
 
+        # Create and write parquet tables
+        tableFilenamer = Filenamer(butler, 'qaTableColor', dataId)
+        writeParquet(forced, tableFilenamer(dataId, description='forced'))
+
         self.plotStarColors(forced, filenamer, NumStarLabeller(len(forcedCatalogsByFilter)), dataId,
                             tractInfo=tractInfo, patchList=patchList, hscRun=hscRun)
         self.plotStarColorColor(forcedCatalogsByFilter, filenamer, dataId, tractInfo=tractInfo,

--- a/python/lsst/pipe/analysis/utils.py
+++ b/python/lsst/pipe/analysis/utils.py
@@ -2,6 +2,7 @@ import os
 import re
 
 import numpy as np
+import fastparquet
 
 from contextlib import contextmanager
 
@@ -23,7 +24,16 @@ __all__ = ["Filenamer", "Data", "Stats", "Enforcer", "MagDiff", "MagDiffMatches"
            "checkIdLists", "checkPatchOverlap", "joinCatalogs", "getFluxKeys", "addColumnsToSchema",
            "addApertureFluxesHSC", "addFpPoint", "addFootprintNPix", "addRotPoint",
            "calibrateSourceCatalogMosaic", "calibrateSourceCatalog", "calibrateCoaddSourceCatalog",
-           "backoutApCorr", "matchJanskyToDn", "checkHscStack", "fluxToPlotString", "andCatalog"]
+           "backoutApCorr", "matchJanskyToDn", "checkHscStack", "fluxToPlotString", "andCatalog", "writeParquet"]
+
+def writeParquet(table, path):
+    """Write a parquet file into repo
+    
+    table is afwTable
+    """
+    df = table.asAstropy().to_pandas()
+    df = df.set_index('id', drop=True)
+    fastparquet.write(path, df)
 
 class Filenamer(object):
     """Callable that provides a filename given a style"""

--- a/python/lsst/pipe/analysis/visitAnalysis.py
+++ b/python/lsst/pipe/analysis/visitAnalysis.py
@@ -220,6 +220,11 @@ class VisitAnalysisTask(CoaddAnalysisTask):
                     self.log.info("HSC run: adding aperture flux to schema...")
                     catalog = addApertureFluxesHSC(catalog, prefix="")
 
+            # Create and write parquet tables
+            tableFilenamer = Filenamer(butler, 'qaTableVisit', dataRefListTract[0].dataId)
+            writeParquet(catalog, tableFilenamer(dataRefListTract[0].dataId, description='catalog'))
+            writeParquet(commonZpCat, tableFilenamer(dataRefListTract[0].dataId, description='commonZp'))
+
             try:
                 self.zpLabel = self.zpLabel + " " + self.catLabel
             except:


### PR DESCRIPTION
The interactive QA plots require fast column-based reading
of data tables (DM-11679).  Here we use the fact that the pipe_analysis
scripts do the reading, merging, and organizing of all the afwTable data,
and persist the same flat tables that get passed on to the matplotlib
plotting routines.