### PR TITLE
DM-13760: Adapt to new jointcal_wcs dataset naming

### DIFF
--- a/python/lsst/pipe/analysis/utils.py
+++ b/python/lsst/pipe/analysis/utils.py
@@ -951,7 +951,7 @@ def getRepoInfo(dataRef, coaddName=None, coaddDataset=None, doApplyUberCal=False
     hscRun = checkHscStack(metadata)
     dataset = "src"
     if doApplyUberCal:
-        dataset = "wcs_hsc" if hscRun is not None else "wcs"
+        dataset = "wcs_hsc" if hscRun is not None else "jointcal_wcs"
     skymap =  butler.get(coaddName + "Coadd_skyMap") if coaddName is not None else None
     wcs = None
     tractInfo = None


### PR DESCRIPTION
This adapts to the new dataset naming for wcs of DM-11138, which
added a jointcal_ prefix.  If no dataset with the new name is found,
the search is performed for the old name to allow for the scripts
to work with older processing runs.