### PR TITLE
DM-14842: Fix deprecation warnings from PropertyList/Set.get

### DIFF
--- a/python/lsst/pipe/analysis/utils.py
+++ b/python/lsst/pipe/analysis/utils.py
@@ -931,7 +931,7 @@ def checkHscStack(metadata):
     """Check to see if data were processed with the HSC stack
     """
     try:
-        hscPipe = metadata.get("HSCPIPE_VERSION")
+        hscPipe = metadata.getScalar("HSCPIPE_VERSION")
     except:
         hscPipe = None
     return hscPipe

--- a/python/lsst/pipe/analysis/visitAnalysis.py
+++ b/python/lsst/pipe/analysis/visitAnalysis.py
@@ -521,7 +521,7 @@ class VisitAnalysisTask(CoaddAnalysisTask):
             self.zpLabel = "MEAS_MOSAIC"
         else:
             # Scale fluxes to measured zeropoint
-            self.zp = 2.5*np.log10(metadata.get("FLUXMAG0"))
+            self.zp = 2.5*np.log10(metadata.getScalar("FLUXMAG0"))
             if self.zpLabel is None:
                 self.log.info("Using 2.5*log10(FLUXMAG0) = {:.4f} from FITS header for zeropoint".format(
                               self.zp))
@@ -899,7 +899,7 @@ class CompareVisitAnalysisTask(CompareCoaddAnalysisTask):
                 self.zpLabel += " MEAS_MOSAIC_2"
         else:
             # Scale fluxes to measured zeropoint
-            self.zp = 2.5*np.log10(metadata.get("FLUXMAG0"))
+            self.zp = 2.5*np.log10(metadata.getScalar("FLUXMAG0"))
             if self.zpLabel is None:
                 self.log.info("Using 2.5*log10(FLUXMAG0) = {:.4f} from FITS header for zeropoint".format(
                     self.zp))


### PR DESCRIPTION
Use `getScalar` or `getArray` instead of deprecated `get`
on `PropertySet` and `PropertyList` instances.