### PR TITLE
DM-15091: Add check for flag in schema before accessing

### DIFF
--- a/python/lsst/pipe/analysis/utils.py
+++ b/python/lsst/pipe/analysis/utils.py
@@ -742,7 +742,8 @@ def makeBadArray(catalog, flagList=[], onlyReadStars=False, patchInnerOnly=True,
     if "detect_isTractInner" in catalog.schema and tractInnerOnly:
         bad |= ~catalog["detect_isTractInner"]
     bad |= catalog["deblend_nChild"] > 0  # Exclude non-deblended (i.e. parents)
-    bad |= catalog["merge_peak_sky"]  # Exclude "sky" objects
+    if "merge_peak_sky" in catalog.schema:
+        bad |= catalog["merge_peak_sky"]  # Exclude "sky" objects (currently only inserted in coadds)
     for flag in flagList:
         bad |= catalog[flag]
     if onlyReadStars and "base_ClassificationExtendedness_value" in catalog.schema:


### PR DESCRIPTION
Sky objects are (currently) only added at the coadd level.  Add check for
existence of "merge_peak_sky" in the catalog before accessing (and culling)
on it to avoid a fatal KeyError when dealing with catalogs at the visit level.