### PR TITLE
DM-2639: {{Standardize primary method names, run/runDataRef, across PipeTasks}}

### DIFF
--- a/python/lsst/pipe/analysis/coaddAnalysis.py
+++ b/python/lsst/pipe/analysis/coaddAnalysis.py
@@ -158,7 +158,7 @@ class CoaddAnalysisTask(CmdLineTask):
         CmdLineTask.__init__(self, *args, **kwargs)
         self.unitScale = 1000.0 if self.config.toMilli else 1.0
 
-    def run(self, patchRefList, cosmos=None):
+    def runDataRef(self, patchRefList, cosmos=None):
         haveForced = False  # do forced datasets exits (may not for single band datasets)
         dataset = "Coadd_forced_src"
         # Explicit input file was checked in CoaddAnalysisRunner, so a check on datasetExists
@@ -1102,7 +1102,7 @@ class CompareCoaddAnalysisTask(CmdLineTask):
         CmdLineTask.__init__(self, *args, **kwargs)
         self.unitScale = 1000.0 if self.config.toMilli else 1.0
 
-    def run(self, patchRefList1, patchRefList2):
+    def runDataRef(self, patchRefList1, patchRefList2):
         haveForced = True  # do forced datasets exits (may not for single band datasets)
         dataset = "Coadd_forced_src"
         patchRefExistsList1 = [patchRef1 for patchRef1 in patchRefList1 if

--- a/python/lsst/pipe/analysis/colorAnalysis.py
+++ b/python/lsst/pipe/analysis/colorAnalysis.py
@@ -317,7 +317,7 @@ class ColorAnalysisTask(CmdLineTask):
         CmdLineTask.__init__(self, *args, **kwargs)
         self.unitScale = 1000.0 if self.config.toMilli else 1.0
 
-    def run(self, patchRefsByFilter):
+    def runDataRef(self, patchRefsByFilter):
         patchList = []
         repoInfo = None
         self.fluxFilter = None

--- a/python/lsst/pipe/analysis/visitAnalysis.py
+++ b/python/lsst/pipe/analysis/visitAnalysis.py
@@ -192,7 +192,7 @@ class VisitAnalysisTask(CoaddAnalysisTask):
                             help="Tract(s) to use (do one at a time for overlapping) e.g. 1^5^0")
         return parser
 
-    def run(self, dataRefList, tract=None):
+    def runDataRef(self, dataRefList, tract=None):
         self.log.info("dataRefList size: {:d}".format(len(dataRefList)))
         if tract is None:
             tractList = [0, ]
@@ -602,7 +602,7 @@ class CompareVisitAnalysisTask(CompareCoaddAnalysisTask):
                             help="Tract(s) to use (do one at a time for overlapping) e.g. 1^5^0")
         return parser
 
-    def run(self, dataRefList1, dataRefList2, tract=None):
+    def runDataRef(self, dataRefList1, dataRefList2, tract=None):
         # This is for the commonZP plots (i.e. all ccds regardless of tract)
         if tract is None:
             tractList = [0, ]


### PR DESCRIPTION
Rename methods according to RFC-352.
Fifteen total repositories with changes.
