### PR TITLE
DM-24254: Eliminate slow calexp retrievals.

### DIFF
--- a/python/lsst/pipe/analysis/coaddAnalysis.py
+++ b/python/lsst/pipe/analysis/coaddAnalysis.py
@@ -582,8 +582,7 @@ class CoaddAnalysisTask(CmdLineTask):
             # Compute Focal Plane coordinates for each source if not already there
             if self.config.analysisMatches.doPlotFP:
                 if "src_base_FPPosition_x" not in catalog.schema and "src_focalplane_x" not in catalog.schema:
-                    exp = butler.get("calexp", dataRef.dataId)
-                    det = exp.getDetector()
+                    det = butler.get("calexp_detector", dataRef.dataId)
                     catalog = addFpPoint(det, catalog, prefix="src_")
             # Optionally backout aperture corrections
             if self.config.doBackoutApCorr:

--- a/python/lsst/pipe/analysis/plotUtils.py
+++ b/python/lsst/pipe/analysis/plotUtils.py
@@ -752,7 +752,7 @@ def buildTractImage(butler, dataId, tractInfo, patchList=None, coaddName="deep")
         expDataId = {"filter": dataId["filter"], "tract": tractInfo.getId(), "patch": patch}
         try:
             exp = butler.get(coaddName + "Coadd_calexp", expDataId, immediate=True)
-            bbox = butler.get(coaddName + "Coadd_calexp_bbox", expDataId, immediate=True)
+            bbox = exp.getBBox()
             tractArray[bbox.getMinY():bbox.getMaxY() + 1,
                        bbox.getMinX():bbox.getMaxX() + 1] = exp.maskedImage.image.array
             nPatches += 1

--- a/python/lsst/pipe/analysis/utils.py
+++ b/python/lsst/pipe/analysis/utils.py
@@ -1239,10 +1239,12 @@ def getRepoInfo(dataRef, coaddName=None, coaddDataset=None, doApplyExternalPhoto
     isCoadd = True if "patch" in dataId else False
     try:
         filterName = dataId["filter"]
-    except Exception:
-        exp = butler.get("calexp", dataId) if not isCoadd else butler.get(coaddName + "Coadd_calexp", dataId)
-        filterName = exp.getFilter().getFilterProperty().getName()
-        dataId.update(dict(filter=filterName))
+    except KeyError:
+        if isCoadd:
+            filterName = butler.get(coaddName + "Coadd_calexp_filter", dataId)
+        else:
+            filterName = butler.get("calexp_filter", dataId)
+        dataId['filter'] = filterName
     genericFilterName = afwImage.Filter(afwImage.Filter(filterName).getId()).getName()
     ccdKey = None if isCoadd else findCcdKey(dataId)
     # Check metadata to see if stack used was HSC


### PR DESCRIPTION
In almost all cases, dataset components can be used to avoid reading pixels.  In one case, a single pixel is read instead in order to get full metadata, plus a slightly hacky method is used to load the mask from an exposure.