### PR TITLE
Use ExposureFitsReader.

### DIFF
--- a/python/lsst/pipe/analysis/utils.py
+++ b/python/lsst/pipe/analysis/utils.py
@@ -1257,8 +1257,7 @@ def getRepoInfo(dataRef, coaddName=None, coaddDataset=None, doApplyExternalPhoto
     tractInfo = None
     if isCoadd:
         coaddImageName = "Coadd_calexp_hsc" if hscRun else "Coadd_calexp"  # To get the coadd's WCS
-        coadd = butler.get(coaddName + coaddImageName, dataId)
-        wcs = coadd.getWcs()
+        wcs = butler.get(coaddName + coaddImageName + "_wcs", dataId)
         catDataset = coaddName + coaddDataset
         tractInfo = skymap[dataId["tract"]]
     photoCalibDataset = None


### PR DESCRIPTION
Also corrects a bug that omitted a "repoInfo.", and allows search through parents with `getUri` unlike `calexp_filename`.