### PR TITLE
DM-25450: Add Rowe statistics to SQuaSH

### DIFF
--- a/python/lsst/pipe/analysis/analysis.py
+++ b/python/lsst/pipe/analysis/analysis.py
@@ -1136,7 +1136,9 @@ class Analysis(object):
                           zpLabel=None, forcedStr=None, postFix="", flagsCat=None, uberCalLabel=None):
         """Plot Rho Statistics.
         """
-        figAxes = [plt.subplots(), plt.subplots()]  # first plot for Rho 1, 3, 4 and second for Rho 2, 5
+
+        figAxes = [plt.subplots(), plt.subplots(), plt.subplots()]
+        # first plot for Rho 1, 3, 4, second for Rho 2, 5 and third for Rho 0
         figs, axes = list(zip(*figAxes))
 
         compareCol = "base_SdssShape"
@@ -1173,7 +1175,9 @@ class Analysis(object):
                          style="RhoStats")
 
         if "ext_shapeHSM_HsmSourceMoments_xx" in self.catalog.schema:
-            figAxes = [plt.subplots(), plt.subplots()]  # first plot for Rho 1, 3, 4 and second for Rho 2, 5
+            figAxes = [plt.subplots(), plt.subplots(), plt.subplots()]
+            # first plot for Rho 1, 3, 4, second for Rho 2, 5
+            # and third for Rho 0.
             figs, axes = list(zip(*figAxes))
 
             description = description.replace("Rho", "hsmRho")

--- a/python/lsst/pipe/analysis/coaddAnalysis.py
+++ b/python/lsst/pipe/analysis/coaddAnalysis.py
@@ -1479,7 +1479,7 @@ class CoaddAnalysisTask(CmdLineTask):
         psfUsed = catalog[catalog["calib_psf_used"]].copy(deep=True)
         self.log.info("shortName = {:s}".format(shortName))
         yield from self.AnalysisClass(psfUsed, None,
-                                      ("        Sdss Rho Statistics (calib_psf_used): "),
+                                      ("        Rho Statistics (calib_psf_used): "),
                                       shortName, self.config.analysis,
                                       goodKeys=["calib_psf_used"], labeller=None
                                       ).plotRhoStatistics(shortName, plotInfoDict, self.log,
@@ -1492,7 +1492,7 @@ class CoaddAnalysisTask(CmdLineTask):
         starsOnly = catalog[catalog["base_ClassificationExtendedness_value"] < 0.5].copy(deep=True)
         self.log.info("shortName = {:s}".format(shortName))
         yield from self.AnalysisClass(starsOnly, None,
-                                      ("        Sdss Rho Statistics: "),
+                                      ("        Rho Statistics: "),
                                       shortName, self.config.analysis, flags=[], labeller=None
                                       ).plotRhoStatistics(shortName, plotInfoDict, self.log,
                                                           treecorrParams=self.config.treecorrParams,

--- a/python/lsst/pipe/analysis/plotUtils.py
+++ b/python/lsst/pipe/analysis/plotUtils.py
@@ -955,22 +955,23 @@ def plotRhoStats(axes, rhoStats):
     Parameters
     ----------
     axes : `list`
-        A list containing two `matplotlib.figure.ax` handles.
+        A list containing three `matplotlib.figure.ax` handles.
     rhoStats : `dict`
         A Python dictionary object with keys 1..5, each containing a
-        `treecorr.GGCorrelation object`.
+        `treecorr.GGCorrelation` object and key 0 containing a
+        `treecorr.KKCorrelation` object.
     """
-    for rhoIndex in range(1, 6):
+    for rhoIndex in range(6):
         rho = rhoStats[rhoIndex]
 
-        # The mapping creates plots as in DES papers:
-        # ax = axes[1] if rhoIndex in [2,5] else axes[0].
-        ax = axes[1 if rhoIndex in (2, 5) else 0]
+        # The mapping creates plots as in DES papers
+        ax = axes[1 if rhoIndex in (2, 5) else 2 if rhoIndex == 0 else 0]
         colorStr = "C{}".format(rhoIndex)
-        isPositive = rho.xip > 0
-        ax.errorbar(rho.meanr[isPositive], rho.xip[isPositive], yerr=np.sqrt(rho.varxi)[isPositive],
+        xi = rho.xip if rhoIndex > 0 else rho.xi
+        isPositive = xi > 0
+        ax.errorbar(rho.meanr[isPositive], xi[isPositive], yerr=np.sqrt(rho.varxi)[isPositive],
                     color=colorStr, fmt="o", label=r"$\rho_{0}(\theta)$".format(rhoIndex))
-        ax.errorbar(rho.meanr[~isPositive], -rho.xip[~isPositive], yerr=np.sqrt(rho.varxi)[~isPositive],
+        ax.errorbar(rho.meanr[~isPositive], -xi[~isPositive], yerr=np.sqrt(rho.varxi)[~isPositive],
                     color=colorStr, fillstyle="none", fmt="o", label=None)
 
     for ax in axes:

--- a/python/lsst/pipe/analysis/utils.py
+++ b/python/lsst/pipe/analysis/utils.py
@@ -2114,7 +2114,7 @@ def addMetricMeasurement(job, metricName, metricValue, measExtrasDictList=None):
     if measExtrasDictList:
         for extra in measExtrasDictList:
             meas.extras[extra["name"]] = verify.Datum(extra["value"], label=extra["label"],
-                                                      description=extra["description"])
+                                                      description=extra["description"], unit="")
     job.measurements.insert(meas)
     return job
 

--- a/python/lsst/pipe/analysis/visitAnalysis.py
+++ b/python/lsst/pipe/analysis/visitAnalysis.py
@@ -556,6 +556,8 @@ class VisitAnalysisTask(CoaddAnalysisTask):
         if plotList:
             savePlots(plotList, "plotVisit", repoInfo.dataId, repoInfo.butler, subdir=subdir)
 
+        # TODO: DM-26758 (or DM-14768) should make the following line a proper
+        # butler.put by directly persisting json files.
         self.verifyJob.write(verifyJobFilename)
 
     def readCatalogs(self, dataRefList, dataset, repoInfo, aliasDictList=None, fakeCat=None,


### PR DESCRIPTION
This PR covers the calculation of several metrics related to Rho Statistics and their inclusion in the verify framework. There is an [associated PR](https://github.com/lsst/verify_metrics/pull/23) in `lsst/verify_metrics` that includes the definition of these new metrics and specifications.